### PR TITLE
Allow guard clauses

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -3,12 +3,11 @@ Ruby
 
 [Sample](sample.rb)
 
-* Avoid conditional modifiers (lines that end with conditionals).
 * Avoid multiple assignments per line (`one, two = 1, 2`).
 * Avoid organizational comments (`# Validations`).
 * Avoid ternary operators (`boolean ? true : false`). Use multi-line `if`
   instead to emphasize code branches.
-* Avoid explicit return statements.
+* Don't use explicit `return` except in guard clauses.
 * Avoid using semicolons.
 * Avoid bang (!) method names. Prefer descriptive names.
 * Don't use `self` explicitly anywhere except class methods (`def self.method`)

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -76,6 +76,11 @@ class SomeClass
     rest_of_body
   end
 
+  def method_with_guard_clause
+    return some_value if some_condition?
+    rest_of_body
+  end
+
   def method_that_uses_factory
     user = user_factory.new
     user.ensure_authenticated!


### PR DESCRIPTION
Guard clauses provide an important use case for explicit `return`
statements. Therefore, the existing guide is hereby adjusted to allow
explicit `return`s before the end of methods, where they are used to
implement guard clauses. Explicit `returns` at the end of Ruby methods,
where they have no effect, should be strictly prohibited, _rather than just avoided_.

A guard clause is an early exit from a block of code. Guard
clauses can be used to simplify and remove conditional logic. They are
implemented in Ruby code by using an explicit, early `return` from a
method or function. In a loop, guard clauses can be implemented
with an explicit, early `next`.

Guard clauses are commonly recommended. They are [recommended by](https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals)
the popular Community Ruby Style Guide and the makers of RuboCop,
as well as [by Jeff Atwood](https://blog.codinghorror.com/spartan-programming/), author of Coding Horror.

More recommendations for guard clauses, in Ruby and other languages,
can be found by Googling for "guard clause", "early return in programming",
and "avoid nested if":

https://sourcemaking.com/refactoring/replace-nested-conditional-with-guard-clauses
http://www.thechrisoshow.com/2009/02/16/using-guard-clauses-in-your-ruby-code/
http://blog.timoxley.com/post/47041269194/avoid-else-return-early
http://refactoring.com/catalog/replaceNestedConditionalWithGuardClauses.html
http://www.codeproject.com/Articles/626403/How-and-Why-to-Avoid-Excessive-Nesting
https://blog.kowalczyk.info/article/1ik/Deeply-nested-if-statements.html
http://www.drdobbs.com/architecture-and-design/refactoring-deeply-nested-code/231500074
http://software-talk.org/blog/2014/09/refactoring-deeply-nested-if-statements/
