### PR TITLE
Change location of data scripting to its own repo

### DIFF
--- a/protocol/database-scripting/README.md
+++ b/protocol/database-scripting/README.md
@@ -9,10 +9,9 @@ Development
 Develop the scripting story similarly to any other story. In this case, this would
 entail running your script at the rails console of your local server during development.
 
-Typically, our scripts should live in the `db/data_migrations/` subdirectory within
-the `healthify/` app repo. In rare cases where that's not feasible, you might use
-a secret [gist](https://help.github.com/articles/about-gists/), whose you link you
-should post on Pivotal Tracker and share with your Code Reviewers.
+Typically, our scripts should live in the `data-scripting` repo. In rare cases where 
+that's not feasible, you might use a secret [gist](https://help.github.com/articles/about-gists/), 
+whose you link you should post on Pivotal Tracker and share with your Code Reviewers.
 
 While some scripts only lend themselves to being performed via pure SQL, where it
 is possible, you should leverage ActiveRecord to perform our `INSERT`/`UPDATE`/`DELETE`


### PR DESCRIPTION
I recently started down the path of adding data scripts to the Healthify app repo and some concerns emerged. First, if the script is not contained within some sort of class, or other object, it risks being eagerly loaded and being run when the app starts, which would not be desirable. This then caused me to go down the path of trying to impose some artificial object-orientedness to the script, when that is unnecessary and not always preferable. Furthermore, keeping the script code in the app repo in my mind pressures me to think about reusability, OOPiness, testability, etc, when I believe we've all agreed that these data scripts are one-offs and we shouldn't be concerned with these aspects. 

I have therefore created a new repository for data scripts to live in and propose this change to keep scripting code separate from our app code. I believe this will reduce the risk of accidentally loading the scripts when we don't need them as well as appropriately keep the styles/approaches/structures separate physically when they are so separate in concept and procedure.