### PR TITLE
Fix inaccuracy in workflow instructions

### DIFF
--- a/protocol/development-workflow/README.md
+++ b/protocol/development-workflow/README.md
@@ -71,7 +71,7 @@ Push the release's staging branch to GitHub.
 
     git push -u origin stage-<release-name>
 
-Open a pull request to merge the release branch into `master`,
+Open a pull request to merge the release's staging branch into `master`,
 triggering a Travis CI build to
 
     * run our full test suite, and if passing,


### PR DESCRIPTION
While trying out the new workflow today with @KrishnaKulkarni and @switzersc, I noticed that one of the instructions says to make a PR for the "release branch" when it should say the "release's staging branch".