### PR TITLE
Update QA protocol to use release branches for QA

### DIFF
--- a/protocol/development-workflow/README.md
+++ b/protocol/development-workflow/README.md
@@ -1,5 +1,12 @@
 # Development Workflow
 
+- [Setting Up the Release Branch](#setting-up-the-release-branch)
+- [Developing for the Release](#developing-for-the-release)
+- [Conducting QA](#conducting-qa)
+  + [Rejecting](#rejecting)
+  + [Accepting and Deploying](#accepting-and-deploying)
+- [Small, discretionary releases](#small-discretionary-releases)
+
 ## Setting Up the Release Branch
 
 As a team, determine the scope of a release. The release can contain one
@@ -56,43 +63,37 @@ Get the most recent state of the release branch.
     git checkout <release-name>
     git pull
 
-Create a QA branch off of `master`.
-
-    git checkout master
-    git pull
-    git checkout -b qa/<release-name>
-
-Merge the release branch into the QA branch.
-
-    git merge <release-name>
+Open a pull request to merge the release branch into `master`, triggering a Travis CI build to run our full test suite.
 
 Copy the QA steps from the Pivotal Tracker story into the PR description, and put the story ID in the PR title. Add the link to the PT story in the description of the PR.
 
-Determine which server is available on the [server spreadsheet](https://docs.google.com/spreadsheets/d/1qZ5x80cYXHxACJbZ20W5MqH6ETRFDmaLTnsjaqen6O0/edit), update the row of your choice, and push to that server.
+**Note**: After creating the PR, Github will let you know whether your release branch is up-to-date with master. If not, please use `git rebase` instead of the update feature on Github (which creates a merge commit).
+
+Wait for Travis CI to finish its build on the pull request.
+
+Determine which server is available on the [server spreadsheet][server-spreadsheet]. Update the row of your choice, and push to that server.
 
     git push <APP REMOTE> head:master --force
 
-Where <APP REMOTE> is the name of the remote you set up for the server of your choice. If you're not sure what's available, use `git remote -v` and refresh yourself by reading the [QA Setup](qa-setup.md) steps.
+Where `<APP REMOTE>` is the name of the remote you set up for the server of your choice. If you're not sure what's available, use `git remote -v` and refresh yourself by reading the [QA Setup](qa-setup.md) steps.
 
-Push the QA branch to GitHub.
-
-    git push -u origin qa/<release-name>
-
-Open a pull request to merge the QA branch into `master`, triggering a Travis CI build to run our full test suite.
-
-Wait for the staging delivery to finish.
-
-Conduct QA through your staging app's frontend. Reference the Server Spreadsheet to find the correct URL for your app.
+Follow the QA steps from Pivotal Tracker, conducting QA through your staging app's frontend, as needed. Reference the [Server Spreadsheet][server-spreadsheet] to find the correct URL for your app.
 
 If required by the specified QA steps, use the staging console.
 
     aptible ssh --app <APP NAME> bin/rails c
 
+Leave comments on the QA pull request as necessary to detail the QA server that was used and steps performed in the QA.
+
 ### Rejecting
 
-Close the QA branch's pull request on GitHub without merging.
+Leave a comment on the QA pull request with reasons why the story did not pass QA.
 
-Delete the QA branch on GitHub.
+Close the QA pull request on GitHub without merging.
+
+Indicate in Pivotal Tracker that the release was rejected. Leave a comment linking to the one made in Github describing why QA did not pass.
+
+Do not delete the release branch.
 
 Rollback the new database migrations, if any, on the staging app.
 
@@ -104,47 +105,38 @@ Reset the staging remote.
     git checkout master
     git push -f <APP REMOTE> master
 
-Delete the QA branch locally.
+Be sure to update the [server spreadsheet](server-spreadsheet) when you are done using a staging server.
 
-    git branch -D qa/<release-name>
-
-Indicate in Pivotal Tracker that the release was rejected.
-
-Be sure to update the server spreadsheet when you are done using a staging server.
+When QA is ready to be performed again, make sure the release branch has been updated and re-open the original QA PR. Modify the PR description as needed.
 
 ### Accepting and Deploying
 
-Merge the pull request on GitHub for the QA branch, triggering
-CI to run all tests and deploy `master` to production.
+Leave a comment on the QA pull request explaining that the release has been accepted and will be deployed.
 
-Delete the QA branch on GitHub.
+Merge the QA pull request on GitHub, triggering CI to run all tests and deploy `master` to production.
+
+Indicate in Pivotal Tracker that the release was accepted. Leave a comment linking to the one made in Github explaining that  QA passed.
+
+Delete the release branch both locally and remotely.
+
+    git branch -d <release-name>
+    git push origin :<release-name>
 
 Update your local `master` branch.
 
     git checkout master
     git pull
 
-Delete the QA branch locally.
-
-    git branch -d qa/<release-name>
-
-Delete the release branches locally and remotely.
-
-    git branch -d <release-name>
-    git push origin :<release-name>
-
-Indicate in Pivotal Tracker that the release was accepted and deployed.
-
 If QA will not be immediately conducted on another story, push the new `master` to the staging app, as well as all unused staging servers.
 
     git push <APP REMOTE> master
 
-Be sure to update the server spreadsheet when you are done using a staging server.
+Be sure to update the [server spreadsheet][server-spreadsheet] when you are done using a staging server.
 
 Further reading:
-[A Successful Git Branching Model](http://nvie.com/posts/a-successful-git-branching-model/)
-[Continuous Delivery (Wikipedia)](https://en.wikipedia.org/wiki/Continuous_delivery)
 
+- [A Successful Git Branching Model](http://nvie.com/posts/a-successful-git-branching-model/)
+- [Continuous Delivery (Wikipedia)](https://en.wikipedia.org/wiki/Continuous_delivery)
 
 ## Small, discretionary releases
 
@@ -166,7 +158,7 @@ their release branch onto a staging server.
 
     git push <staging-remote> head:master
 
-> Don't forget to update the [Server Status Spreadsheet](https://docs.google.com/spreadsheets/d/1qZ5x80cYXHxACJbZ20W5MqH6ETRFDmaLTnsjaqen6O0/edit#gid=0) before and after you perform QA.
+> Don't forget to update the [Server Status Spreadsheet][server-spreadsheet] before and after you perform QA.
 
 Note: In the case of a dependency update, QA involves deploying to a staging server and ensuring that the application doesn't crash.
 
@@ -175,3 +167,5 @@ are still in ship shape.
 
 Given that it passes on staging, the developer may merge their
 pull request into master.
+
+[server-spreadsheet]: https://docs.google.com/spreadsheets/d/1qZ5x80cYXHxACJbZ20W5MqH6ETRFDmaLTnsjaqen6O0/edit


### PR DESCRIPTION
Discussed during Retro on 2017-12-07: https://trello.com/c/v8sOkH5f

QA branches are effectively the same as release branches, except are children of master. We can conduct QA off of release branches, as they should be rebased against master before QA begins anyway. If changes need to be made, they can get pushed to the release branch, instead of QA, too.