### PR TITLE
Revises and clarifies Code Maintainer policy

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -14,20 +14,14 @@ For more information, review the [ISMS policy documentation in Aptible][isms-pol
 
 ### Policy
 
-* For every Healthify codebase that contains sensitive data, one or many code
+* For every Healthify codebase that contains sensitive code, one or many code
   maintainers are defined.
-* A code maintainer (CM) is defined as someone that has worked at Healthify for 90
-  days and has been approved by engineering leadership to be a code maintainer.
-* If you are a CM:
-  * When developing software you still must receive code review, but code review
-    may happen by any developer, whether they are a CM or not.
-* If you are not a CM:
-  * When developing software, you must receive an approved code review by a CM.
-  * When performing code review, you must not approve a pull request in the
-    Github web UI.
-    * With that said, you can (and are encouraged to) perform code review.
-    * After completing your review, request review from a CM so that they can
-      sign-off on the pull request.
+* Every pull request (PR) to such a codebase requires an explicit Github 'Approve' action from
+a qualified code reviewer. If the code has been paired on, then one of the members of the pair can 'Approve' it.
+* A code maintainer (CM) is defined as someone that has has been approved by engineering leadership to be a code maintainer, typically after working at Healthify for 90 days. A code maintainer may give an 'Approve' to any PR.
+* When you first join Healthify, you may not 'Approve' any PR, but you may comment or review them and in fact you are encouraged to!
+* After 30 days at Healthify and a sync up with your manager, you may be granted privileges to 'Approve'
+any PR submitted by a CM. This is an intermediary stage between being a complete neoHealthifyte and a CM.
 
 ## General Guidance
 


### PR DESCRIPTION
- Removes ambiguity about whether a non-CM may review a CM's code
- Introduces intermediary stage between complete noob privileges and full CM privileges

**Note:** This may need to be moved over to our new wiki. cc @onebree 